### PR TITLE
Fix GPU pixel indexing and drawText bounds checks

### DIFF
--- a/src/shared/java/com/tom/peripherals/gpu/BaseGPU.java
+++ b/src/shared/java/com/tom/peripherals/gpu/BaseGPU.java
@@ -224,10 +224,11 @@ public class BaseGPU extends TMLuaObject {
 			String s = ParamCheck.getString(a, 2);
 			char[] chars = s.toCharArray();
 			int l = getTextLength(chars, size, padding);
-			if (x < 0 || (l + x) > ctx.getWidth()) {
-				throw new LuaException("Out of boundary x " + x + ":" + (l + x));
+			int drawnLen = bg > -1 ? l : l - padding * size;
+			if (x < 0 || (drawnLen + x) > ctx.getWidth()) {
+				throw new LuaException("Out of boundary x " + x + ":" + (drawnLen + x));
 			}
-			if (y < 0 || (y + selectedFont.fontHeight) > ctx.getHeight()) {
+			if (y < 0 || (y + selectedFont.fontHeight * size) > ctx.getHeight()) {
 				throw new LuaException("Out of boundary y");
 			}
 			int wx = x;

--- a/src/shared/java/com/tom/peripherals/gpu/LuaImage.java
+++ b/src/shared/java/com/tom/peripherals/gpu/LuaImage.java
@@ -105,16 +105,25 @@ public class LuaImage extends ReferenceableLuaObject implements GPUContext, VRAM
 
 	@LuaMethod
 	public void setRGB(Object[] a) throws LuaException {
-		int x = ParamCheck.getInt(a, 0) + 1;
-		int y = ParamCheck.getInt(a, 1) + 1;
+		if (image == null)throw new LuaException("Error: Use after free");
+		int x = ParamCheck.getInt(a, 0) - 1;
+		int y = ParamCheck.getInt(a, 1) - 1;
+		checkBounds(x, y);
 		int rgb = ParamCheck.toColor(a, 2);
 		image.setRGB(x, y, rgb);
 	}
 
 	@LuaMethod
 	public int getRGB(Object[] a) throws LuaException {
-		int x = ParamCheck.getInt(a, 0) + 1;
-		int y = ParamCheck.getInt(a, 1) + 1;
+		if (image == null)throw new LuaException("Error: Use after free");
+		int x = ParamCheck.getInt(a, 0) - 1;
+		int y = ParamCheck.getInt(a, 1) - 1;
+		checkBounds(x, y);
 		return image.getRGB(x, y);
+	}
+
+	private void checkBounds(int x, int y) throws LuaException {
+		if (x < 0 || y < 0 || x >= image.getWidth() || y >= image.getHeight())
+			throw new LuaException("Out of boundary: " + (x + 1) + "," + (y + 1));
 	}
 }


### PR DESCRIPTION
LuaImage.setRGB/getRGB: Lua's 1-based coords were not correctly handled
 fixed to use -1 (not +1) so they hit the right pixel

Update to reject out-of-range coords with an "Out of boundary" error
 instead of a raw Java exception.

drawText: don't count trailing padding against the width when there's
 no background.  Scale the height check by text size so large text near
 the bottom edge is rejected cleanly instead of silently drawing out
 of bounds.